### PR TITLE
Separate WAM model from scene, fix whitespace

### DIFF
--- a/barrett/bhand.xml
+++ b/barrett/bhand.xml
@@ -1,28 +1,28 @@
 <!-- ======================================================
-	This file is part of MuJoCo.
-	Copyright 2009-2015 Roboti LLC.
+  This file is part of MuJoCo.
+  Copyright 2009-2015 Roboti LLC.
 
-	Model 		:: Barrett hand from Barrett technologies
-		Source		: https://github.com/jhu-lcsr/barrett_model
-		Downloaded	: 10Oct'15
+  Model     :: Barrett hand from Barrett technologies
+    Source      : https://github.com/jhu-lcsr/barrett_model
+    Downloaded  : 10Oct'15
 
-	Mujoco		:: Advanced physics simulation engine
-		Source		: www.roboti.us
-		Version		: 1.22
-		Released 	: 26Nov15
+  Mujoco    :: Advanced physics simulation engine
+    Source      : www.roboti.us
+    Version     : 1.22
+    Released    : 26Nov15
 
-	Author		:: Vikash Kumar
-		Contacts 	: kumar@roboti.us
-		Last edits 	: 26Dec'15
+  Author    :: Vikash Kumar
+    Contacts    : kumar@roboti.us
+    Last edits  : 26Dec'15
 ====================================================== -->
 
 <mujoco model="bhand(v1.22)">
-	<compiler coordinate="local" angle="radian" meshdir="meshes/" />
-	<include file="include_bhandDependencies.xml"/>
+  <compiler coordinate="local" angle="radian" meshdir="meshes/" />
+  <include file="include_bhandDependencies.xml"/>
 
-	<worldbody>
-		<light directional="true" cutoff="60" exponent="1" diffuse="1 1 1" specular=".1 .1 .1" pos=".1 .2 1.3" dir="-.1 -.2 -1.3"/>
-		<include file="include_bhandChain.xml"/>
-	</worldbody>
+  <worldbody>
+    <light directional="true" cutoff="60" exponent="1" diffuse="1 1 1" specular=".1 .1 .1" pos=".1 .2 1.3" dir="-.1 -.2 -1.3"/>
+    <include file="include_bhandChain.xml"/>
+  </worldbody>
 
 </mujoco>

--- a/barrett/include_bhandChain.xml
+++ b/barrett/include_bhandChain.xml
@@ -1,80 +1,80 @@
 <!-- ======================================================
-	This file is part of MuJoCo.
-	Copyright 2009-2015 Roboti LLC.
+  This file is part of MuJoCo.
+  Copyright 2009-2015 Roboti LLC.
 
-	Model 		:: Barrett hand from Barrett technologies
-		Source		: https://github.com/jhu-lcsr/barrett_model
-		Downloaded	: 10Oct'15
+  Model     :: Barrett hand from Barrett technologies
+    Source      : https://github.com/jhu-lcsr/barrett_model
+    Downloaded  : 10Oct'15
 
-	Mujoco		:: Advanced physics simulation engine
-		Source		: www.roboti.us
-		Version		: 1.22
-		Released 	: 26Nov15
+  Mujoco    :: Advanced physics simulation engine
+    Source      : www.roboti.us
+    Version     : 1.22
+    Released    : 26Nov15
 
-	Author		:: Vikash Kumar
-		Contacts 	: kumar@roboti.us
-		Last edits 	: 26Dec'15
+  Author    :: Vikash Kumar
+    Contacts    : kumar@roboti.us
+    Last edits  : 26Dec'15
 ====================================================== -->
 
 <mujocoinclude>
-	<body name="wam/bhand/bhand_palm_link" childclass="wam/bhand" pos="0 0 0.06" quat="0 0 0 1">
-		<inertial pos="-5.1098e-005 0.0050433 0.036671" quat="0.553098 0.439047 0.434456 0.559078" mass="0.50573" diaginertia="0.000224052 0.000210701 2.81212e-005" />
-		<geom class="wam/bhandViz" mesh="bhand_palm_fine"/>
-		<geom mesh="bhand_palm_link_convex_decomposition_p1"/>
-		<geom mesh="bhand_palm_link_convex_decomposition_p2"/>
-		<geom mesh="bhand_palm_link_convex_decomposition_p3"/>
-		<geom mesh="bhand_palm_link_convex_decomposition_p4"/>
-		<body name="wam/bhand/finger_1/prox_link" pos="-0.025 0 0.0415" quat="0.707107 0 0 -0.707107">
-			<inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.14109" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
-			<joint name="wam/bhand/finger_1/prox_joint" axis="0 0 -1" range="0 3.14159" damping="0.11"/>
-			<geom class="wam/bhandViz" mesh="bhand_finger_prox_link_fine"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p1"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p2"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p3"/>
-			<body name="wam/bhand/finger_1/med_link" pos="0.05 0 0.0339" quat="0.707107 0.707107 0 0">
-				<inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
-				<joint name="wam/bhand/finger_1/med_joint" range="0 2.44346" damping="0.11"/>
-				<geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
-				<geom mesh="bhand_finger_med_link_convex"/>
-				<body name="wam/bhand/finger_1/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
-					<inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
-					<joint name="wam/bhand/finger_1/dist_joint" range="0 0.837758" damping="0.11"/>
-					<geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
-					<geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
-				</body>
-			</body>
-		</body>
-		<body name="wam/bhand/finger_2/prox_link" pos="0.025 0 0.0415" quat="0.707107 0 0 -0.707107">
-			<inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.14109" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
-			<joint name="wam/bhand/finger_2/prox_joint" range="0 3.14159" damping="0.11"/>
-			<geom class="wam/bhandViz" mesh="bhand_finger_prox_link_fine"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p1"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p2"/>
-			<geom mesh="bhand_finger_prox_link_convex_decomposition_p3"/>
-			<body name="wam/bhand/finger_2/med_link" pos="0.05 0 0.0339" quat="0.707107 0.707107 0 0">
-				<inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
-				<joint name="wam/bhand/finger_2/med_joint" range="0 2.44346" damping="0.11"/>
-				<geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
-				<geom mesh="bhand_finger_med_link_convex"/>
-				<body name="wam/bhand/finger_2/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
-					<inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
-					<joint name="wam/bhand/finger_2/dist_joint" range="0 0.837758" damping="0.11"/>
-					<geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
-					<geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
-				</body>
-			</body>
-		</body>
-		<body name="wam/bhand/finger_3/med_link" pos="0 0.05 0.0754" quat="0.5 0.5 0.5 0.5">
-			<inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
-			<joint name="wam/bhand/finger_3/med_joint" range="0 2.44346" damping="0.11"/>
-			<geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
-			<geom mesh="bhand_finger_med_link_convex"/>
-			<body name="wam/bhand/finger_3/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
-				<inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
-				<joint name="wam/bhand/finger_3/dist_joint" range="0 0.837758" damping="0.11"/>
-				<geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
-				<geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
-			</body>
-		</body>
-	</body>
+  <body name="wam/bhand/bhand_palm_link" childclass="wam/bhand" pos="0 0 0.06" quat="0 0 0 1">
+    <inertial pos="-5.1098e-005 0.0050433 0.036671" quat="0.553098 0.439047 0.434456 0.559078" mass="0.50573" diaginertia="0.000224052 0.000210701 2.81212e-005" />
+    <geom class="wam/bhandViz" mesh="bhand_palm_fine"/>
+    <geom mesh="bhand_palm_link_convex_decomposition_p1"/>
+    <geom mesh="bhand_palm_link_convex_decomposition_p2"/>
+    <geom mesh="bhand_palm_link_convex_decomposition_p3"/>
+    <geom mesh="bhand_palm_link_convex_decomposition_p4"/>
+    <body name="wam/bhand/finger_1/prox_link" pos="-0.025 0 0.0415" quat="0.707107 0 0 -0.707107">
+      <inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.14109" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
+      <joint name="wam/bhand/finger_1/prox_joint" axis="0 0 -1" range="0 3.14159" damping="0.11"/>
+      <geom class="wam/bhandViz" mesh="bhand_finger_prox_link_fine"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p1"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p2"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p3"/>
+      <body name="wam/bhand/finger_1/med_link" pos="0.05 0 0.0339" quat="0.707107 0.707107 0 0">
+        <inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
+        <joint name="wam/bhand/finger_1/med_joint" range="0 2.44346" damping="0.11"/>
+        <geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
+        <geom mesh="bhand_finger_med_link_convex"/>
+        <body name="wam/bhand/finger_1/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
+          <inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
+          <joint name="wam/bhand/finger_1/dist_joint" range="0 0.837758" damping="0.11"/>
+          <geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
+          <geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
+        </body>
+      </body>
+    </body>
+    <body name="wam/bhand/finger_2/prox_link" pos="0.025 0 0.0415" quat="0.707107 0 0 -0.707107">
+      <inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.14109" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
+      <joint name="wam/bhand/finger_2/prox_joint" range="0 3.14159" damping="0.11"/>
+      <geom class="wam/bhandViz" mesh="bhand_finger_prox_link_fine"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p1"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p2"/>
+      <geom mesh="bhand_finger_prox_link_convex_decomposition_p3"/>
+      <body name="wam/bhand/finger_2/med_link" pos="0.05 0 0.0339" quat="0.707107 0.707107 0 0">
+        <inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
+        <joint name="wam/bhand/finger_2/med_joint" range="0 2.44346" damping="0.11"/>
+        <geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
+        <geom mesh="bhand_finger_med_link_convex"/>
+        <body name="wam/bhand/finger_2/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
+          <inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
+          <joint name="wam/bhand/finger_2/dist_joint" range="0 0.837758" damping="0.11"/>
+          <geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
+          <geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
+        </body>
+      </body>
+    </body>
+    <body name="wam/bhand/finger_3/med_link" pos="0 0.05 0.0754" quat="0.5 0.5 0.5 0.5">
+      <inertial pos="0.023133 0.00078642 0.00052792" quat="0.0160796 0.707269 -0.000766008 0.706762" mass="0.062139" diaginertia="7.77335e-005 7.66282e-005 4.83122e-006" />
+      <joint name="wam/bhand/finger_3/med_joint" range="0 2.44346" damping="0.11"/>
+      <geom class="wam/bhandViz" mesh="bhand_finger_med_link_fine"/>
+      <geom mesh="bhand_finger_med_link_convex"/>
+      <body name="wam/bhand/finger_3/dist_link" pos="0.06994 0.003 0" quat="0.92388 0 0 0.382683">
+        <inertial pos="0.022825 0.0010491 0.0004203" quat="0.508412 0.51165 0.489583 0.489939" mass="0.041377" diaginertia="3.8434e-005 3.72753e-005 3.09987e-006" />
+        <joint name="wam/bhand/finger_3/dist_joint" range="0 0.837758" damping="0.11"/>
+        <geom class="wam/bhandViz" mesh="bhand_finger_dist_link_fine" euler="0 0 -.84"/>
+        <geom mesh="bhand_finger_dist_link_convex" euler="0 0 -.84"/>
+      </body>
+    </body>
+  </body>
 </mujocoinclude>

--- a/barrett/include_bhandDependencies.xml
+++ b/barrett/include_bhandDependencies.xml
@@ -1,46 +1,46 @@
 <!-- ======================================================
-	This file is part of MuJoCo.
-	Copyright 2009-2015 Roboti LLC.
+  This file is part of MuJoCo.
+  Copyright 2009-2015 Roboti LLC.
 
-	Model 		:: Barrett hand from Barrett technologies
-		Source		: https://github.com/jhu-lcsr/barrett_model
-		Downloaded	: 10Oct'15
+  Model     :: Barrett hand from Barrett technologies
+    Source      : https://github.com/jhu-lcsr/barrett_model
+    Downloaded  : 10Oct'15
 
-	Mujoco		:: Advanced physics simulation engine
-		Source		: www.roboti.us
-		Version		: 1.22
-		Released 	: 26Nov15
+  Mujoco    :: Advanced physics simulation engine
+    Source      : www.roboti.us
+    Version     : 1.22
+    Released    : 26Nov15
 
-	Author		:: Vikash Kumar
-		Contacts 	: kumar@roboti.us
-		Last edits 	: 26Dec'15
+  Author    :: Vikash Kumar
+    Contacts    : kumar@roboti.us
+    Last edits  : 26Dec'15
 ====================================================== -->
 
 <mujocoinclude>
-	<asset>
-		<mesh file="bhand_palm_fine.stl"/>
-		<mesh file="bhand_palm_link_convex_decomposition_p1.stl"/>
-		<mesh file="bhand_palm_link_convex_decomposition_p2.stl"/>
-		<mesh file="bhand_palm_link_convex_decomposition_p3.stl"/>
-		<mesh file="bhand_palm_link_convex_decomposition_p4.stl"/>
-		<mesh file="bhand_finger_prox_link_fine.stl"/>
-		<mesh file="bhand_finger_prox_link_convex_decomposition_p1.stl"/>
-		<mesh file="bhand_finger_prox_link_convex_decomposition_p2.stl"/>
-		<mesh file="bhand_finger_prox_link_convex_decomposition_p3.stl"/>
-		<mesh file="bhand_finger_med_link_fine.stl"/>
-		<mesh file="bhand_finger_med_link_convex.stl"/>
-		<mesh file="bhand_finger_dist_link_fine.stl"/>
-		<mesh file="bhand_finger_dist_link_convex.stl"/>
-	</asset>
+  <asset>
+    <mesh file="bhand_palm_fine.stl"/>
+    <mesh file="bhand_palm_link_convex_decomposition_p1.stl"/>
+    <mesh file="bhand_palm_link_convex_decomposition_p2.stl"/>
+    <mesh file="bhand_palm_link_convex_decomposition_p3.stl"/>
+    <mesh file="bhand_palm_link_convex_decomposition_p4.stl"/>
+    <mesh file="bhand_finger_prox_link_fine.stl"/>
+    <mesh file="bhand_finger_prox_link_convex_decomposition_p1.stl"/>
+    <mesh file="bhand_finger_prox_link_convex_decomposition_p2.stl"/>
+    <mesh file="bhand_finger_prox_link_convex_decomposition_p3.stl"/>
+    <mesh file="bhand_finger_med_link_fine.stl"/>
+    <mesh file="bhand_finger_med_link_convex.stl"/>
+    <mesh file="bhand_finger_dist_link_fine.stl"/>
+    <mesh file="bhand_finger_dist_link_convex.stl"/>
+  </asset>
 
-	<default>
-		<default class="wam/bhand">
-			<joint type="hinge" limited="true" pos="0 0 0" axis="0 0 1" frictionloss=".001"/>
-			<geom type="mesh" contype="0" conaffinity="1" group="0" rgba="0.5 0.6 0.7 0"/>
-		</default>
-		<default class="wam/bhandViz">
-			<geom type="mesh" contype="0" conaffinity="0" group="1" rgba="0.7 0.8 0.8 1"/>
-		</default>
-	</default>
+  <default>
+    <default class="wam/bhand">
+      <joint type="hinge" limited="true" pos="0 0 0" axis="0 0 1" frictionloss=".001"/>
+      <geom type="mesh" contype="0" conaffinity="1" group="0" rgba="0.5 0.6 0.7 0"/>
+    </default>
+    <default class="wam/bhandViz">
+      <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="0.7 0.8 0.8 1"/>
+    </default>
+  </default>
 
 </mujocoinclude>

--- a/barrett/scene.xml
+++ b/barrett/scene.xml
@@ -1,0 +1,21 @@
+<mujoco model="wam scene">
+  <include file="wam_7dof_wam_bhand.xml"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="120" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+  </worldbody>
+</mujoco>

--- a/barrett/wam_7dof_wam_bhand.xml
+++ b/barrett/wam_7dof_wam_bhand.xml
@@ -1,126 +1,126 @@
 <!-- ======================================================
-	This file is part of MuJoCo.
-	Copyright 2009-2016 Roboti LLC.
+  This file is part of MuJoCo.
+  Copyright 2009-2016 Roboti LLC.
 
-	Model 		:: WAM Arm from Barrett technologies
-		Source		: https://github.com/jhu-lcsr/barrett_model
-		Downloaded	: 10Oct'15
+  Model     :: WAM Arm from Barrett technologies
+    Source      : https://github.com/jhu-lcsr/barrett_model
+    Downloaded  : 10Oct'15
 
-	Mujoco		:: Advanced physics simulation engine
-		Source		: www.roboti.us
-		Version		: 1.31
-		Released 	: 23Apr'16
+  Mujoco    :: Advanced physics simulation engine
+    Source      : www.roboti.us
+    Version     : 1.31
+    Released    : 23Apr'16
 
-	Author		:: Vikash Kumar
-		Contacts 	: kumar@roboti.us
-		Last edits 	: 30Apr16, 6Dec'15
+  Author    :: Vikash Kumar
+    Contacts    : kumar@roboti.us
+    Last edits  : 30Apr16, 6Dec'15
 ====================================================== -->
 
 <mujoco model="wam(v1.31)">
-    <compiler coordinate="local" angle="radian" meshdir="meshes/" />
-    <default>
-            <joint type="hinge" limited="true" pos="0 0 0" axis="0 0 1" frictionloss=".001"/>
-            <default class="viz">
-                    <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="0.7 0.7 0.7 1"/>
-            </default>
-            <default class="col">
-                    <geom type="mesh" contype="0" conaffinity="1" group="0" rgba="0.5 0.6 0.7 0"/>
-            </default>
+  <compiler coordinate="local" angle="radian" meshdir="meshes/" />
+  <default>
+    <joint type="hinge" limited="true" pos="0 0 0" axis="0 0 1" frictionloss=".001"/>
+    <default class="viz">
+      <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="0.7 0.7 0.7 1"/>
     </default>
+    <default class="col">
+      <geom type="mesh" contype="0" conaffinity="1" group="0" rgba="0.5 0.6 0.7 0"/>
+    </default>
+  </default>
 
-    <asset>
-            <mesh file="base_link_fine.stl"/>
-            <mesh file="base_link_convex.stl"/>
-            <mesh file="shoulder_link_fine.stl"/>
-            <mesh file="shoulder_link_convex_decomposition_p1.stl"/>
-            <mesh file="shoulder_link_convex_decomposition_p2.stl"/>
-            <mesh file="shoulder_link_convex_decomposition_p3.stl"/>
-            <mesh file="shoulder_pitch_link_fine.stl"/>
-            <mesh file="shoulder_pitch_link_convex.stl"/>
-            <mesh file="upper_arm_link_fine.stl"/>
-            <mesh file="upper_arm_link_convex_decomposition_p1.stl"/>
-            <mesh file="upper_arm_link_convex_decomposition_p2.stl"/>
-            <mesh file="elbow_link_fine.stl"/>
-            <mesh file="elbow_link_convex.stl"/>
-            <mesh file="forearm_link_fine.stl"/>
-            <mesh file="forearm_link_convex_decomposition_p1.stl"/>
-            <mesh file="forearm_link_convex_decomposition_p2.stl"/>
-            <mesh file="wrist_yaw_link_fine.stl"/>
-            <mesh file="wrist_yaw_link_convex_decomposition_p1.stl"/>
-            <mesh file="wrist_yaw_link_convex_decomposition_p2.stl"/>
-            <mesh file="wrist_pitch_link_fine.stl"/>
-            <mesh file="wrist_pitch_link_convex_decomposition_p1.stl"/>
-            <mesh file="wrist_pitch_link_convex_decomposition_p2.stl"/>
-            <mesh file="wrist_pitch_link_convex_decomposition_p3.stl"/>
-            <mesh file="wrist_palm_link_fine.stl"/>
-            <mesh file="wrist_palm_link_convex.stl"/>
-    </asset>
-    <include file="include_bhandDependencies.xml"/>
+  <asset>
+    <mesh file="base_link_fine.stl"/>
+    <mesh file="base_link_convex.stl"/>
+    <mesh file="shoulder_link_fine.stl"/>
+    <mesh file="shoulder_link_convex_decomposition_p1.stl"/>
+    <mesh file="shoulder_link_convex_decomposition_p2.stl"/>
+    <mesh file="shoulder_link_convex_decomposition_p3.stl"/>
+    <mesh file="shoulder_pitch_link_fine.stl"/>
+    <mesh file="shoulder_pitch_link_convex.stl"/>
+    <mesh file="upper_arm_link_fine.stl"/>
+    <mesh file="upper_arm_link_convex_decomposition_p1.stl"/>
+    <mesh file="upper_arm_link_convex_decomposition_p2.stl"/>
+    <mesh file="elbow_link_fine.stl"/>
+    <mesh file="elbow_link_convex.stl"/>
+    <mesh file="forearm_link_fine.stl"/>
+    <mesh file="forearm_link_convex_decomposition_p1.stl"/>
+    <mesh file="forearm_link_convex_decomposition_p2.stl"/>
+    <mesh file="wrist_yaw_link_fine.stl"/>
+    <mesh file="wrist_yaw_link_convex_decomposition_p1.stl"/>
+    <mesh file="wrist_yaw_link_convex_decomposition_p2.stl"/>
+    <mesh file="wrist_pitch_link_fine.stl"/>
+    <mesh file="wrist_pitch_link_convex_decomposition_p1.stl"/>
+    <mesh file="wrist_pitch_link_convex_decomposition_p2.stl"/>
+    <mesh file="wrist_pitch_link_convex_decomposition_p3.stl"/>
+    <mesh file="wrist_palm_link_fine.stl"/>
+    <mesh file="wrist_palm_link_convex.stl"/>
+  </asset>
+  <include file="include_bhandDependencies.xml"/>
 
-    <worldbody>
-        <light name="top" pos="0 0 2" mode="trackcom"/>
-        <body name="wam/base_link" pos="0 0 .3">
-            <inertial pos="0 0 0" mass="1" diaginertia="0.1 0.1 0.1" />
-            <geom class="viz" mesh="base_link_fine"/>
-            <geom class="col" mesh="base_link_convex"/>
-            <body name="wam/shoulder_yaw_link" pos="0 0 0.346">
-                <inertial pos="-0.00443422 -0.00066489 -0.128904" quat="0.69566 0.716713 -0.0354863 0.0334839" mass="5" diaginertia="0.135089 0.113095 0.0904426" />
-                <joint name="wam/base_yaw_joint" range="-2.6 2.6" damping="1.98"/>
-                <geom class="viz" mesh="shoulder_link_fine"/>
-                <geom class="col" mesh="shoulder_link_convex_decomposition_p1"/>
-                <geom class="col" mesh="shoulder_link_convex_decomposition_p2"/>
-                <geom class="col" mesh="shoulder_link_convex_decomposition_p3"/>
-                <body name="wam/shoulder_pitch_link" pos="0 0 0" quat="0.707107 -0.707107 0 0">
-                    <inertial pos="-0.00236981 -0.0154211 0.0310561" quat="0.961794 0.273112 -0.0169316 0.00866592" mass="3.87494" diaginertia="0.0214195 0.0167127 0.0126452" /> <!--seems off-->
-                    <joint name="wam/shoulder_pitch_joint" range="-1.985 1.985" damping="0.55"/>
-                    <geom class="viz" mesh="shoulder_pitch_link_fine"/>
-                    <geom class="col" mesh="shoulder_pitch_link_convex"/>
-                    <body name="wam/upper_arm_link" pos="0 0 0" quat="0.707107 0.707107 0 0">
-                        <inertial pos="0.00683259 3.309e-005 0.392492" quat="0.647136 0.0170822 0.0143038 0.762049" mass="2.20228" diaginertia="0.0592718 0.0592207 0.00313419" />
-                        <joint name="wam/shoulder_yaw_joint" range="-2.8 2.8" damping="1.65"/>
-                        <geom class="viz" mesh="upper_arm_link_fine"/>
-                        <geom class="col" mesh="upper_arm_link_convex_decomposition_p1"/>
-                        <geom class="col" mesh="upper_arm_link_convex_decomposition_p2"/>
-                        <body name="wam/forearm_link" pos="0.045 0 0.55" quat="0.707107 -0.707107 0 0">
-                            <inertial pos="-0.0400149 -0.142717 -0.00022942" quat="0.704281 0.706326 0.0180333 0.0690353" mass="0.500168" diaginertia="0.0151047 0.0148285 0.00275805" />
-                            <joint name="wam/elbow_pitch_joint" range="-0.9 3.14159" damping="0.88"/>
-                            <geom class="viz" mesh="elbow_link_fine"/>
-                            <geom class="col" mesh="elbow_link_convex"/>
-                            <geom class="viz" mesh="forearm_link_fine" pos="-.045 -0.0730 0" euler="1.57 0 0"/>
-                            <geom class="col" mesh="forearm_link_convex_decomposition_p1" pos="-0.045 -0.0730 0" euler="1.57 0 0"/>
-                            <geom class="col" mesh="forearm_link_convex_decomposition_p2" pos="-.045 -0.0730 0" euler="1.57 0 0"/>
-                            <body name="wam/wrist_yaw_link" pos="-0.045 -0.3 0" quat="0.707107 0.707107 0 0">
-                                <inertial pos="8.921e-005 0.00435824 -0.00511217" quat="0.630602 0.776093 0.00401969 -0.002372" mass="1.05376" diaginertia="0.000555168 0.00046317 0.000234072" /> <!--this is an approximation-->
-                                <joint name="wam/wrist_yaw_joint" range="-4.55 1.25" damping="0.55"/>
-                                <geom class="viz" mesh="wrist_yaw_link_fine"/>
-                                <geom class="col" mesh="wrist_yaw_link_convex_decomposition_p1"/>
-                                <geom class="col" mesh="wrist_yaw_link_convex_decomposition_p2"/>
-                                <body name="wam/wrist_pitch_link" pos="0 0 0" quat="0.707107 -0.707107 0 0">
-                                    <inertial pos="-0.00012262 -0.0246834 -0.0170319" quat="0.630602 0.776093 0.00401969 -0.002372" mass="0.517974" diaginertia="0.000555168 0.00046317 0.000234072" />
-                                    <joint name="wam/wrist_pitch_joint" range="-1.5707 1.5707" damping="0.11"/>
-                                    <geom class="viz" mesh="wrist_pitch_link_fine"/>
-                                    <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p1"/>
-                                    <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p2"/>
-                                    <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p3"/>
-                                    <body name="wam/wrist_palm_link" pos="0 0 0" quat="0.707107 0.707107 0 0">
-                                        <!-- Site added at the gripper. Useful for things like EE tracking. -->
-                                        <site name="ee_site" size="0.01" pos="0 0 0.175" rgba="1 0 0 1" group="2"/>
-                                        <inertial pos="0 0 0.055" quat="0.707107 0 0 0.707107" mass="0.0828613" diaginertia="0.00020683 0.00010859 0.00010851" />
-                                        <joint name="wam/palm_yaw_joint" range="-3 3" damping="0.11"/>
-                                        <geom class="viz" mesh="wrist_palm_link_fine"/>
-                                        <geom class="col" mesh="wrist_palm_link_convex"/>
-                                        <include file="include_bhandChain.xml"/>
-                                    </body>
-                                </body>
-                            </body>
-                        </body>
-                    </body>
+  <worldbody>
+    <light name="top" pos="0 0 2" mode="trackcom"/>
+    <body name="wam/base_link" pos="0 0 .3">
+      <inertial pos="0 0 0" mass="1" diaginertia="0.1 0.1 0.1" />
+      <geom class="viz" mesh="base_link_fine"/>
+      <geom class="col" mesh="base_link_convex"/>
+      <body name="wam/shoulder_yaw_link" pos="0 0 0.346">
+        <inertial pos="-0.00443422 -0.00066489 -0.128904" quat="0.69566 0.716713 -0.0354863 0.0334839" mass="5" diaginertia="0.135089 0.113095 0.0904426" />
+        <joint name="wam/base_yaw_joint" range="-2.6 2.6" damping="1.98"/>
+        <geom class="viz" mesh="shoulder_link_fine"/>
+        <geom class="col" mesh="shoulder_link_convex_decomposition_p1"/>
+        <geom class="col" mesh="shoulder_link_convex_decomposition_p2"/>
+        <geom class="col" mesh="shoulder_link_convex_decomposition_p3"/>
+        <body name="wam/shoulder_pitch_link" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+          <inertial pos="-0.00236981 -0.0154211 0.0310561" quat="0.961794 0.273112 -0.0169316 0.00866592" mass="3.87494" diaginertia="0.0214195 0.0167127 0.0126452" /> <!--seems off-->
+          <joint name="wam/shoulder_pitch_joint" range="-1.985 1.985" damping="0.55"/>
+          <geom class="viz" mesh="shoulder_pitch_link_fine"/>
+          <geom class="col" mesh="shoulder_pitch_link_convex"/>
+          <body name="wam/upper_arm_link" pos="0 0 0" quat="0.707107 0.707107 0 0">
+            <inertial pos="0.00683259 3.309e-005 0.392492" quat="0.647136 0.0170822 0.0143038 0.762049" mass="2.20228" diaginertia="0.0592718 0.0592207 0.00313419" />
+            <joint name="wam/shoulder_yaw_joint" range="-2.8 2.8" damping="1.65"/>
+            <geom class="viz" mesh="upper_arm_link_fine"/>
+            <geom class="col" mesh="upper_arm_link_convex_decomposition_p1"/>
+            <geom class="col" mesh="upper_arm_link_convex_decomposition_p2"/>
+            <body name="wam/forearm_link" pos="0.045 0 0.55" quat="0.707107 -0.707107 0 0">
+              <inertial pos="-0.0400149 -0.142717 -0.00022942" quat="0.704281 0.706326 0.0180333 0.0690353" mass="0.500168" diaginertia="0.0151047 0.0148285 0.00275805" />
+              <joint name="wam/elbow_pitch_joint" range="-0.9 3.14159" damping="0.88"/>
+              <geom class="viz" mesh="elbow_link_fine"/>
+              <geom class="col" mesh="elbow_link_convex"/>
+              <geom class="viz" mesh="forearm_link_fine" pos="-.045 -0.0730 0" euler="1.57 0 0"/>
+              <geom class="col" mesh="forearm_link_convex_decomposition_p1" pos="-0.045 -0.0730 0" euler="1.57 0 0"/>
+              <geom class="col" mesh="forearm_link_convex_decomposition_p2" pos="-.045 -0.0730 0" euler="1.57 0 0"/>
+              <body name="wam/wrist_yaw_link" pos="-0.045 -0.3 0" quat="0.707107 0.707107 0 0">
+                <inertial pos="8.921e-005 0.00435824 -0.00511217" quat="0.630602 0.776093 0.00401969 -0.002372" mass="1.05376" diaginertia="0.000555168 0.00046317 0.000234072" /> <!--this is an approximation-->
+                <joint name="wam/wrist_yaw_joint" range="-4.55 1.25" damping="0.55"/>
+                <geom class="viz" mesh="wrist_yaw_link_fine"/>
+                <geom class="col" mesh="wrist_yaw_link_convex_decomposition_p1"/>
+                <geom class="col" mesh="wrist_yaw_link_convex_decomposition_p2"/>
+                <body name="wam/wrist_pitch_link" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+                  <inertial pos="-0.00012262 -0.0246834 -0.0170319" quat="0.630602 0.776093 0.00401969 -0.002372" mass="0.517974" diaginertia="0.000555168 0.00046317 0.000234072" />
+                  <joint name="wam/wrist_pitch_joint" range="-1.5707 1.5707" damping="0.11"/>
+                  <geom class="viz" mesh="wrist_pitch_link_fine"/>
+                  <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p1"/>
+                  <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p2"/>
+                  <geom class="col" mesh="wrist_pitch_link_convex_decomposition_p3"/>
+                  <body name="wam/wrist_palm_link" pos="0 0 0" quat="0.707107 0.707107 0 0">
+                    <!-- Site added at the gripper. Useful for things like EE tracking. -->
+                    <site name="ee_site" size="0.01" pos="0 0 0.175" rgba="1 0 0 1" group="2"/>
+                    <inertial pos="0 0 0.055" quat="0.707107 0 0 0.707107" mass="0.0828613" diaginertia="0.00020683 0.00010859 0.00010851" />
+                    <joint name="wam/palm_yaw_joint" range="-3 3" damping="0.11"/>
+                    <geom class="viz" mesh="wrist_palm_link_fine"/>
+                    <geom class="col" mesh="wrist_palm_link_convex"/>
+                    <include file="include_bhandChain.xml"/>
+                  </body>
                 </body>
+              </body>
             </body>
+          </body>
         </body>
-    </worldbody>
+      </body>
+    </body>
+  </worldbody>
 
-    <keyframe>
-        <key name="home" qpos="0.0 0.81 0.0 1.7 0.0 0.63 0.0 0.0 1.22 0.0 0.0 1.22 0.0 1.22 0.0"/>
-    </keyframe>
+  <keyframe>
+    <key name="home" qpos="0.0 0.81 0.0 1.7 0.0 0.63 0.0 0.0 1.22 0.0 0.0 1.22 0.0 1.22 0.0"/>
+  </keyframe>
 </mujoco>

--- a/barrett/wam_7dof_wam_bhand.xml
+++ b/barrett/wam_7dof_wam_bhand.xml
@@ -28,12 +28,6 @@
             </default>
     </default>
 
-    <visual>
-        <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-        <rgba haze="0.15 0.25 0.35 1"/>
-        <global azimuth="120" elevation="-20"/>
-    </visual>
-
     <asset>
             <mesh file="base_link_fine.stl"/>
             <mesh file="base_link_convex.stl"/>
@@ -60,18 +54,11 @@
             <mesh file="wrist_pitch_link_convex_decomposition_p3.stl"/>
             <mesh file="wrist_palm_link_fine.stl"/>
             <mesh file="wrist_palm_link_convex.stl"/>
-
-            <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
-            <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
-              markrgb="0.8 0.8 0.8" width="300" height="300"/>
-            <material name="MatGnd" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
     </asset>
     <include file="include_bhandDependencies.xml"/>
 
     <worldbody>
-        <light pos="0 0 1.5" dir="0 0 -1" directional="true"/>
-        <geom name="floor" type="plane" pos="0 0 0" size="0 0 .05" material="MatGnd"/>
-
+        <light name="top" pos="0 0 2" mode="trackcom"/>
         <body name="wam/base_link" pos="0 0 .3">
             <inertial pos="0 0 0" mass="1" diaginertia="0.1 0.1 0.1" />
             <geom class="viz" mesh="base_link_fine"/>


### PR DESCRIPTION
Added a separate `scene.xml` that includes the wam xml file, instead of having the scene embedded into the wam xml file. That way, the wam model can be included in other files as needed